### PR TITLE
`FFI::Platypus` is a configuration dependency; list it as such.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -38,6 +38,7 @@ Capture::Tiny = 0
 File::ShareDir::Dist::Install = 0
 File::chdir = 0
 Path::Tiny = 0
+FFI::Platypus = 0
 
 [Author::Plicease::Upload]
 cpan = 1


### PR DESCRIPTION
When running `perl Makefile.PL`, `inc/config.pl` will get loaded, which contains the line `use FFI::Platypus`.  Thus, it is a configuration/build time dependency, not just a run-time dependency.